### PR TITLE
Selectable cells

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ animation:
 * [x] Use react-move <NodeGroup /> that uses the data processor to animate the treemap in the way already established in IHME-UI react-move branches.
 
 zoom logic: 
-* [ ] when at a leaf, zoom out should go to direct parent?
+* [x] when at a leaf, zoom out should go to direct parent?
 
 prototype specific functionality:
 * [ ] UI element such as a slider to control depth/breakdown
@@ -63,7 +63,7 @@ prototype specific functionality:
 * [ ] use propResolver where available, streamline what gets fed to components.
   * [ ] implement `keyField` rest of common accessors.
 * [x] Implement selected cells (sort data putting selected cells last)
-* [ ] Implement onmouseover/hover for focused node.
+* [x] Implement onmouseover/hover for focused node.
 * [ ] get rid of `any`s where possible. 
 * [x] fix bug where label's are not being scaled.
 * [x] Refactor consumed classes to not call their own static functions.

--- a/src/components/TreemapCell.tsx
+++ b/src/components/TreemapCell.tsx
@@ -1,3 +1,4 @@
+import includes from 'lodash-es/includes';
 import React from 'react';
 
 import DoubleClickReactComponent, {
@@ -27,6 +28,7 @@ interface TreemapCellProps extends DoubleClickComponentProps {
   onMouseOver: (...args: any[]) => void;
   opacity: number;
   rotate: number;
+  selection?: number[] | string[];
   stroke: string;
   strokeWidth: number | string;
   width: number;
@@ -165,11 +167,17 @@ extends DoubleClickReactComponent<TreemapCellProps, {}> {
   renderRect = () => {
     const {
       cellFill,
+      datum,
+      selection,
       stroke,
       strokeWidth,
       height,
       width,
     } = this.props;
+
+    // TODO: DO THIS `combineStyles` a la IHME-UI `Shape`
+    const isSelected = includes(selection, datum.id);
+    const style = isSelected ? { stroke: 'red' } : {};
 
     return (
       <rect
@@ -181,6 +189,7 @@ extends DoubleClickReactComponent<TreemapCellProps, {}> {
         onMouseOver={this.onMouseOver}
         stroke={stroke}
         strokeWidth={strokeWidth}
+        style={style}
         width={Math.max(0, width)}
       />
     );

--- a/src/components/TreemapCell.tsx
+++ b/src/components/TreemapCell.tsx
@@ -30,6 +30,7 @@ interface TreemapCellProps extends DoubleClickComponentProps {
   label: string;
   onClick: (...args: any[]) => void;
   onDoubleClick: (...args: any[]) => void;
+  onMouseEnter: (...args: any[]) => void;
   onMouseLeave: (...args: any[]) => void;
   onMouseMove: (...args: any[]) => void;
   onMouseOver: (...args: any[]) => void;
@@ -153,6 +154,15 @@ extends DoubleClickReactComponent<
     super.handleClicks(event, this.props.datum, this);
   }
 
+  onMouseEnter = event => {
+    const {
+      datum,
+      onMouseEnter,
+    } = this.props;
+
+    onMouseEnter(event, datum, this);
+  }
+
   onMouseLeave = event => {
     const {
       datum,
@@ -235,6 +245,7 @@ extends DoubleClickReactComponent<
     <rect
       height={Math.max(0, this.props.height)}
       onClick={this.handleClicks}
+      onMouseEnter={this.onMouseEnter}
       onMouseLeave={this.onMouseLeave}
       onMouseMove={this.onMouseMove}
       onMouseOver={this.onMouseOver}

--- a/src/components/TreemapCell.tsx
+++ b/src/components/TreemapCell.tsx
@@ -28,7 +28,7 @@ interface TreemapCellProps extends DoubleClickComponentProps {
   onMouseOver: (...args: any[]) => void;
   opacity: number;
   rotate: number;
-  selection?: number[] | string[];
+  selected: boolean;
   stroke: string;
   strokeWidth: number | string;
   width: number;
@@ -167,17 +167,14 @@ extends DoubleClickReactComponent<TreemapCellProps, {}> {
   renderRect = () => {
     const {
       cellFill,
-      datum,
-      selection,
+      selected,
       stroke,
       strokeWidth,
       height,
       width,
     } = this.props;
 
-    // TODO: DO THIS `combineStyles` a la IHME-UI `Shape`
-    const isSelected = includes(selection, datum.id);
-    const style = isSelected ? { stroke: 'red' } : {};
+    const style = selected ? { stroke: 'red' } : {};
 
     return (
       <rect

--- a/src/components/TreemapCell.tsx
+++ b/src/components/TreemapCell.tsx
@@ -36,10 +36,10 @@ interface TreemapCellProps extends DoubleClickComponentProps {
   opacity: number;
   rotate: number;
   selected: boolean;
-  selectedStyle?: any;
+  selectedStyle?: React.CSSProperties;
   stroke: string;
   strokeWidth: number | string;
-  style?: any;
+  style?: React.CSSProperties;
   width: number;
   x0: number;
   x1: number;
@@ -50,7 +50,7 @@ interface TreemapCellProps extends DoubleClickComponentProps {
 }
 
 interface TreemapCellState {
-  style: any;
+  style: React.CSSProperties;
 }
 
 export default class TreemapCell

--- a/src/components/TreemapCell.tsx
+++ b/src/components/TreemapCell.tsx
@@ -69,7 +69,7 @@ extends DoubleClickReactComponent<
    */
   static propUpdates = {
     style: (acc, _, prevProps, nextProps) => {
-      if (!propsChanged(prevProps, nextProps, [
+      const stylePropNames = [
         'cellFill',
         'focused',
         'focusedStyle',
@@ -78,7 +78,9 @@ extends DoubleClickReactComponent<
         'stroke',
         'strokeWidth',
         'style',
-      ])) {
+      ];
+
+      if (!propsChanged(prevProps, nextProps, stylePropNames)) {
         return acc;
       }
 

--- a/src/components/TreemapCell.tsx
+++ b/src/components/TreemapCell.tsx
@@ -21,6 +21,8 @@ interface TreemapCellProps extends DoubleClickComponentProps {
   colorScale?: (input: number | string) => string;
   datum: any;
   defsUrl: string;
+  focused?: boolean;
+  focusedStyle: React.CSSProperties;
   fontSize: number;
   fontPadding: number;
   fontSizeExtent: [number, number];

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -69,6 +69,8 @@ interface TreemapProps {
   defsUrl?: string;
   doubleClickTiming?: number;
   dataAccessors: TreemapDataAccessors;
+  focused?: string | number;
+  focusedStyle?: React.CSSProperties;
   fontPadding?: number;
   fontSize?: number;
   fontSizeExtent?: [number, number];
@@ -104,6 +106,7 @@ export default class Treemap extends React.PureComponent<
   static defaultProps = {
     animate: DEFAULT_OPACITY_ANIMATION,
     colorScale: scaleOrdinal(schemeCategory10),
+    focusedStyle: { stroke: 'red' },
     fontPadding: 8,
     fontMargin: 3,
     fontSize: 12,
@@ -117,7 +120,7 @@ export default class Treemap extends React.PureComponent<
     onMouseOver: noop,
     onMouseLeave: noop,
     onMouseMove: noop,
-    selectedStyle: { stroke: 'red' },
+    selectedStyle: { stroke: 'green' },
     showToDepth: 1,
     stroke: '#fff',
     strokeWidth: 3,
@@ -130,6 +133,7 @@ export default class Treemap extends React.PureComponent<
     layout: (acc, _, prevProps, nextProps, state) => {
       const animationPropNames = [
         'data',
+        'focused',
         'height',
         'width',
         'rootNodeId',
@@ -215,7 +219,16 @@ export default class Treemap extends React.PureComponent<
   /**
    * Get data laid out in a treemap form.
    */
-  static layoutData({ data, showToDepth, rootNodeId, selection }, layout) {
+  static layoutData(
+    {
+      data,
+      focused,
+      showToDepth,
+      rootNodeId,
+      selection,
+    },
+    layout,
+  ) {
     const unsorted = layout(data).descendants();
 
     const filtered = unsorted.filter(({ children, depth, ...node }) => (
@@ -226,8 +239,10 @@ export default class Treemap extends React.PureComponent<
       && Treemap.nodeHasRootAsAncestor(rootNodeId, node)
     ));
 
+    const selectedAndFocused = [...(selection || []), focused];
+
     // Sort the data, leaving any selected Ids on top of treemap.
-    return sortBy(filtered, datum => findIndex(selection, select => select === datum.id));
+    return sortBy(filtered, datum => findIndex(selectedAndFocused, select => select === datum.id));
   }
 
   static nodeHasRootAsAncestor(rootNodeId, node) {
@@ -420,6 +435,8 @@ export default class Treemap extends React.PureComponent<
       doubleClickTiming,
       defsUrl,
       dataAccessors,
+      focused,
+      focusedStyle,
       fontPadding,
       fontSizeExtent,
       onClick,
@@ -441,6 +458,8 @@ export default class Treemap extends React.PureComponent<
         defsUrl={defsUrl}
         dataAccessors={dataAccessors}
         doubleClickTiming={doubleClickTiming}
+        focused={focused === datum.id}
+        focusedStyle={focusedStyle}
         fontPadding={fontPadding}
         fontSizeExtent={fontSizeExtent}
         onClick={onClick}

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -82,11 +82,12 @@ interface TreemapProps {
   onMouseMove?: (...args: any[]) => void;
   onMouseOver?: (...args: any[]) => void;
   rootNodeId?: number | string;
-  selectedStyle?: any; // TODO: what types are style in geo-app?
+  selectedStyle?: React.CSSProperties;
   selection?: number[] | string[];
   showToDepth: number;
   stroke?: string;
   strokeWidth?: number | string;
+  style?: React.CSSProperties;
   width: number;
 }
 

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -223,11 +223,8 @@ export default class Treemap extends React.PureComponent<
       && Treemap.nodeHasRootAsAncestor(rootNodeId, node)
     ));
 
-    return (
-      selection
-        ? sortBy(filtered, datum => findIndex(selection, selected => selected.includes(datum.id)))
-        : filtered
-    );
+    // Sort the data, leaving any selected Ids on top of treemap.
+    return sortBy(filtered, datum => findIndex(selection, select => select === datum.id));
   }
 
   static nodeHasRootAsAncestor(rootNodeId, node) {

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -79,7 +79,7 @@ interface TreemapProps {
   onMouseMove?: (...args: any[]) => void;
   onMouseOver?: (...args: any[]) => void;
   rootNodeId?: number | string;
-  selected?: number | number[] | string | string[];
+  selection?: number[] | string[];
   showToDepth: number;
   stroke?: string;
   strokeWidth?: number | string;
@@ -131,6 +131,7 @@ export default class Treemap extends React.PureComponent<
         'width',
         'rootNodeId',
         'showToDepth',
+        'selection',
       ];
 
       if (!propsChanged(prevProps, nextProps, animationPropNames)) {
@@ -426,6 +427,7 @@ export default class Treemap extends React.PureComponent<
       onMouseLeave,
       onMouseMove,
       onMouseOver,
+      selection,
       stroke,
       strokeWidth,
     } = this.props;
@@ -445,6 +447,7 @@ export default class Treemap extends React.PureComponent<
         onMouseLeave={onMouseLeave}
         onMouseMove={onMouseMove}
         onMouseOver={onMouseOver}
+        selection={selection}
         stroke={stroke}
         strokeWidth={strokeWidth}
         {...processedDatum}

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -107,7 +107,6 @@ export default class Treemap extends React.PureComponent<
   static defaultProps = {
     animate: DEFAULT_OPACITY_ANIMATION,
     colorScale: scaleOrdinal(schemeCategory10),
-    focusedStyle: { stroke: 'red' },
     fontPadding: 8,
     fontMargin: 3,
     fontSize: 12,
@@ -121,7 +120,6 @@ export default class Treemap extends React.PureComponent<
     onMouseOver: noop,
     onMouseLeave: noop,
     onMouseMove: noop,
-    selectedStyle: { stroke: 'green' },
     showToDepth: 1,
     stroke: '#fff',
     strokeWidth: 3,

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -80,6 +80,7 @@ interface TreemapProps {
   onMouseMove?: (...args: any[]) => void;
   onMouseOver?: (...args: any[]) => void;
   rootNodeId?: number | string;
+  selectedStyle?: any; // TODO: what types are style in geo-app?
   selection?: number[] | string[];
   showToDepth: number;
   stroke?: string;
@@ -116,6 +117,7 @@ export default class Treemap extends React.PureComponent<
     onMouseOver: noop,
     onMouseLeave: noop,
     onMouseMove: noop,
+    selectedStyle: { stroke: 'red' },
     showToDepth: 1,
     stroke: '#fff',
     strokeWidth: 3,
@@ -426,6 +428,7 @@ export default class Treemap extends React.PureComponent<
       onMouseMove,
       onMouseOver,
       selection,
+      selectedStyle,
       stroke,
       strokeWidth,
     } = this.props;
@@ -446,6 +449,7 @@ export default class Treemap extends React.PureComponent<
         onMouseMove={onMouseMove}
         onMouseOver={onMouseOver}
         selected={includes(selection, datum.id)}
+        selectedStyle={selectedStyle}
         stroke={stroke}
         strokeWidth={strokeWidth}
         {...processedDatum}

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -217,8 +217,8 @@ export default class Treemap extends React.PureComponent<
     const filtered = unsorted.filter(({ children, depth, ...node }) => (
       // At the current depth
       (depth === showToDepth
-        // or at a previous depth without children
-        || (depth < showToDepth && !children))
+      // or at a previous depth without children
+      || (depth < showToDepth && !children))
       && Treemap.nodeHasRootAsAncestor(rootNodeId, node)
     ));
 

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -14,6 +14,7 @@ import {
   stateFromPropUpdates,
 } from 'ihme-ui';
 import findIndex from 'lodash-es/findIndex';
+import includes from 'lodash-es/includes';
 import noop from 'lodash-es/noop';
 import partial from 'lodash-es/partial';
 import sortBy from 'lodash-es/sortBy';
@@ -444,7 +445,7 @@ export default class Treemap extends React.PureComponent<
         onMouseLeave={onMouseLeave}
         onMouseMove={onMouseMove}
         onMouseOver={onMouseOver}
-        selection={selection}
+        selected={includes(selection, datum.id)}
         stroke={stroke}
         strokeWidth={strokeWidth}
         {...processedDatum}

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -198,7 +198,7 @@ export default class Treemap extends React.PureComponent<
   /**
    * Get or update a treemap layout function.
    */
-  static getLayout = ({ width, height, ...props }, layout) => {
+  static getLayout = ({ width, height, layoutOptions }, layout) => {
     if (layout) {
       // If a layout already exists, return it with an updated height.
       return layout.size([width, height]);
@@ -208,7 +208,7 @@ export default class Treemap extends React.PureComponent<
       padding,
       round,
       tile,
-    } = props.layoutOptions;
+    } = layoutOptions;
 
     return treemap()
       .tile(tile)
@@ -255,7 +255,7 @@ export default class Treemap extends React.PureComponent<
     if (node.id === rootNodeId) {
       return true;
     }
-    // If we've reaced the base of the hierarchy without finding the root return false
+    // If we've reached the base of the hierarchy without finding the root, return false.
     if (!node.parent) {
       return false;
     }

--- a/src/containers/Treemap.tsx
+++ b/src/containers/Treemap.tsx
@@ -78,6 +78,7 @@ interface TreemapProps {
   layoutOptions?: LayoutOptions;
   onClick?: (...args: any[]) => void;
   onDoubleClick?: (...args: any[]) => void;
+  onMouseEnter?: (...args: any[]) => void;
   onMouseLeave?: (...args: any[]) => void;
   onMouseMove?: (...args: any[]) => void;
   onMouseOver?: (...args: any[]) => void;
@@ -119,6 +120,7 @@ extends React.PureComponent<
     },
     onClick: noop,
     onMouseOver: noop,
+    onMouseEnter: noop,
     onMouseLeave: noop,
     onMouseMove: noop,
     showToDepth: 1,
@@ -449,6 +451,7 @@ extends React.PureComponent<
       fontSizeExtent,
       onClick,
       onDoubleClick,
+      onMouseEnter,
       onMouseLeave,
       onMouseMove,
       onMouseOver,
@@ -472,6 +475,7 @@ extends React.PureComponent<
         fontSizeExtent={fontSizeExtent}
         onClick={onClick}
         onDoubleClick={onDoubleClick}
+        onMouseEnter={onMouseEnter}
         onMouseLeave={onMouseLeave}
         onMouseMove={onMouseMove}
         onMouseOver={onMouseOver}

--- a/src/containers/TreemapView.tsx
+++ b/src/containers/TreemapView.tsx
@@ -11,6 +11,7 @@ interface TreemapViewProps {
 }
 
 interface TreemapViewState {
+  focused?: number | string;
   rootNodeId?: number | string;
   selection?: number[] | string[];
   showToDepth: number;
@@ -100,8 +101,8 @@ export default class TreemapView extends React.PureComponent<
     });
   }
 
-  onMouseOver = (_, node) => { // enter/leave
-    this.setState({ selection: [node.id] });
+  onMouseOver = (_, node) => {
+    this.setState({ focused: node.id });
   }
 
   render() {
@@ -113,6 +114,7 @@ export default class TreemapView extends React.PureComponent<
     } = this.props;
 
     const {
+      focused,
       rootNodeId,
       selection,
       showToDepth,
@@ -123,6 +125,7 @@ export default class TreemapView extends React.PureComponent<
         data={data}
         rootNodeId={rootNodeId}
         dataAccessors={dataAccessors}
+        focused={focused}
         showToDepth={showToDepth}
         onClick={this.zoomIn}
         onDoubleClick={this.zoomOut}

--- a/src/containers/TreemapView.tsx
+++ b/src/containers/TreemapView.tsx
@@ -17,6 +17,10 @@ interface TreemapViewState {
   showToDepth: number;
 }
 
+// Basic focused/selected styles for development.
+const FOCUSED_STYLE = { stroke: 'red' };
+const SELECTED_STYLE = { stroke: 'green' };
+
 export default class TreemapView extends React.PureComponent<
   TreemapViewProps,
   TreemapViewState
@@ -126,12 +130,14 @@ export default class TreemapView extends React.PureComponent<
         rootNodeId={rootNodeId}
         dataAccessors={dataAccessors}
         focused={focused}
+        focusedStyle={FOCUSED_STYLE}
         showToDepth={showToDepth}
         onClick={this.zoomIn}
         onDoubleClick={this.zoomOut}
         onMouseOver={this.onMouseOver}
         defsUrl="url(#dropshadow)"
         selection={selection}
+        selectedStyle={SELECTED_STYLE}
         height={height}
         width={width}
       />

--- a/src/containers/TreemapView.tsx
+++ b/src/containers/TreemapView.tsx
@@ -106,7 +106,15 @@ export default class TreemapView extends React.PureComponent<
   }
 
   onMouseOver = (_, node) => {
-    this.setState({ focused: node.id });
+    if (node.id !== this.state.focused) {
+      this.setState({ focused: node.id });
+    }
+  }
+
+  onMouseLeave = (_, node) => {
+    if (node.id === this.state.focused) {
+      this.setState({ focused: null });
+    }
   }
 
   render() {
@@ -135,6 +143,7 @@ export default class TreemapView extends React.PureComponent<
         onClick={this.zoomIn}
         onDoubleClick={this.zoomOut}
         onMouseOver={this.onMouseOver}
+        onMouseLeave={this.onMouseLeave}
         defsUrl="url(#dropshadow)"
         selection={selection}
         selectedStyle={SELECTED_STYLE}

--- a/src/containers/TreemapView.tsx
+++ b/src/containers/TreemapView.tsx
@@ -12,6 +12,7 @@ interface TreemapViewProps {
 
 interface TreemapViewState {
   rootNodeId?: number | string;
+  selection?: number[] | string[];
   showToDepth: number;
 }
 

--- a/src/containers/TreemapView.tsx
+++ b/src/containers/TreemapView.tsx
@@ -100,6 +100,10 @@ export default class TreemapView extends React.PureComponent<
     });
   }
 
+  onMouseOver = (_, node) => { // enter/leave
+    this.setState({ selection: [node.id] });
+  }
+
   render() {
     const {
       data,
@@ -110,6 +114,7 @@ export default class TreemapView extends React.PureComponent<
 
     const {
       rootNodeId,
+      selection,
       showToDepth,
     } = this.state;
 
@@ -121,7 +126,9 @@ export default class TreemapView extends React.PureComponent<
         showToDepth={showToDepth}
         onClick={this.zoomIn}
         onDoubleClick={this.zoomOut}
+        onMouseOver={this.onMouseOver}
         defsUrl="url(#dropshadow)"
+        selection={selection}
         height={height}
         width={width}
       />


### PR DESCRIPTION
[DV-23](https://jira.ihme.washington.edu/browse/DV-23)

Beth had wanted a treemap cell to be selectable (or multiple) so they would be outlined different. Since the IHME-UI spec seems to allow for a component to have `selection`, `focus` I implemented those properties and style properties for when a cell's datum id matches those.

In order for a `focused`/`selected` cell's outline stroke to be fully seen it needs to not be covered by other cells. There's two schools of thought on how to do this. Evan likes to duplicate the selected, focused cell on top. But that is somewhat of a messy operation in React. We have to add another render function...and then we need handle prioritizing focused cells over selected cells...Gabe had recommended sorting the data in the order in which it should be shown, and there are a bunch of IHME-UI components that do that. So that's what I went with. The data is sorted then rendered. If performance becomes an issue we can pivot to Evan's method.

Cheers!
-Jim

Oh! just a heads up, I have another branch (off of this one) that attempts to `type` everything there was an `any` for. So I'll have another PR up after this one. 

Sorry for all the PRs!